### PR TITLE
fix:catalan intents punctuation

### DIFF
--- a/locale/ca-es/antonym.intent
+++ b/locale/ca-es/antonym.intent
@@ -1,3 +1,3 @@
-(digues|digue'm|digues-me|dona|dóna|dona'm|dóna'm|indica|indica'm|quin és|vull saber) (l|s)'antònim de {query}
+(digues|digue'm|digues-me|dona|dóna|dona'm|dóna'm|indica|indica'm|quin és|vull saber) (l'|s'|)antònim de {query}
 (digues|digue'm|digues-me|dona|dóna|dona'm|dóna'm|indica|indica'm|quins són|vull saber) els antònims de {query}
 (digues|digue'm|digues-me|dona|dóna|dona'm|dóna'm|indica|indica'm|què és|vull saber) un antònim de {query}

--- a/locale/ca-es/holonym.intent
+++ b/locale/ca-es/holonym.intent
@@ -1,3 +1,3 @@
-(digues|digue'm|digues-me|dona|dóna|dona'm|dóna'm|indica|indica'm|quin és|vull saber) (l|s)'holònim de {query}
+(digues|digue'm|digues-me|dona|dóna|dona'm|dóna'm|indica|indica'm|quin és|vull saber) (l'|s'|)holònim de {query}
 (digues|digue'm|digues-me|dona|dóna|dona'm|dóna'm|indica|indica'm|quins són|vull saber) els holònims de {query}
 (digues|digue'm|digues-me|dona|dóna|dona'm|dóna'm|indica|indica'm|què és|vull saber) un holònim de {query}

--- a/translations/ca-es/intents.json
+++ b/translations/ca-es/intents.json
@@ -6,7 +6,7 @@
   ],
   "antonym.intent": [
     "(digues|digue'm|digues-me|dona|dóna|dona'm|dóna'm|indica|indica'm|què és|vull saber) un antònim de {query}",
-    "(digues|digue'm|digues-me|dona|dóna|dona'm|dóna'm|indica|indica'm|quin és|vull saber) (l|s)'antònim de {query}",
+    "(digues|digue'm|digues-me|dona|dóna|dona'm|dóna'm|indica|indica'm|quin és|vull saber) (l'|s'|)antònim de {query}",
     "(digues|digue'm|digues-me|dona|dóna|dona'm|dóna'm|indica|indica'm|quins són|vull saber) els antònims de {query}"
   ],
   "hyponym.intent": [
@@ -16,7 +16,7 @@
   ],
   "holonym.intent": [
     "(digues|digue'm|digues-me|dona|dóna|dona'm|dóna'm|indica|indica'm|què és|vull saber) un holònim de {query}",
-    "(digues|digue'm|digues-me|dona|dóna|dona'm|dóna'm|indica|indica'm|quin és|vull saber) (l|s)'holònim de {query}",
+    "(digues|digue'm|digues-me|dona|dóna|dona'm|dóna'm|indica|indica'm|quin és|vull saber) (l'|s'|)holònim de {query}",
     "(digues|digue'm|digues-me|dona|dóna|dona'm|dóna'm|indica|indica'm|quins són|vull saber) els holònims de {query}"
   ],
   "definition.intent": [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
	- Enhanced language intent matching for Catalan translations
	- Expanded regex patterns to support more flexible input variations for antonym and holonym queries
	- Improved language understanding by allowing optional article variations in intent recognition

<!-- end of auto-generated comment: release notes by coderabbit.ai -->