### PR TITLE
feat: broaden en-US intent coverage and pronoun slot exclusion

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -12,4 +12,4 @@ jobs:
     with:
       python_versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
       install_extras: 'test'
-      test_path: 'test'
+      test_path: 'test/unittests'

--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -13,3 +13,4 @@ jobs:
       python_versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
       install_extras: 'test'
       test_path: 'test/unittests'
+      system_deps: 'swig libfann-dev'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,6 +12,6 @@ jobs:
     with:
       python_version: '3.11'
       coverage_source: 'ovos_skill_wordnet'
-      test_path: 'test/'
+      test_path: 'test/unittests'
       install_extras: ''
       min_coverage: 0

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -9,3 +9,8 @@ jobs:
   license_check:
     uses: OpenVoiceOS/gh-automations/.github/workflows/license-check.yml@dev
     secrets: inherit
+    with:
+      # httpx (BSD-3-Clause, permissive) is pulled transitively by `wn`. Its
+      # current pre-release ships license metadata pilosus cannot parse, so it
+      # is flagged "Error"; excluded by name since the license itself is safe.
+      exclude_packages: '(?i:^httpx([=<>!~ @;].*)?$)'

--- a/.github/workflows/ovoscope.yml
+++ b/.github/workflows/ovoscope.yml
@@ -13,3 +13,5 @@ jobs:
       python_version: '3.11'
       install_extras: 'test'
       test_path: 'test/end2end/'
+      require_padatious: true
+      require_adapt: true

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include ovos_skill_wordnet/locale *

--- a/ovos_skill_wordnet/__init__.py
+++ b/ovos_skill_wordnet/__init__.py
@@ -9,7 +9,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Optional, Tuple
+import re
+from typing import Optional, Set, Tuple
 
 from ovos_bus_client.session import SessionManager
 from ovos_utils.process_utils import RuntimeRequirements
@@ -35,6 +36,29 @@ class WordnetSkill(FallbackSkill):
     def initialize(self) -> None:
         self.engine = WordnetRetrievalEngine(config=dict(self.settings))
 
+    def _slot_blacklist(self, lang: str) -> Set[str]:
+        """Return the values that may not fill the {word} slot for ``lang``.
+
+        Reads ``word.blacklist`` and resolves any ``<voc>`` reference to the
+        matching vocabulary file, so an anaphoric pronoun (or bare determiner)
+        cannot be looked up as if it were a dictionary word.
+        """
+        path = self.find_resource("word.blacklist", lang=lang)
+        if not path:
+            return set()
+        terms: Set[str] = set()
+        with open(path) as blacklist:
+            for line in blacklist:
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                voc = re.match(r"^<(.+)>$", line)
+                if voc:
+                    terms.update(v.lower() for v in self.voc_list(voc.group(1), lang=lang))
+                else:
+                    terms.add(line.lower())
+        return terms
+
     # ------------------------------------------------------------------
     # Common Query pipeline
     # ------------------------------------------------------------------
@@ -51,10 +75,16 @@ class WordnetSkill(FallbackSkill):
     # Explicit intent
     # ------------------------------------------------------------------
 
-    @intent_handler("search_wordnet.intent")
+    @intent_handler("search_wordnet.intent",
+                    voc_blacklist=["pronoun", "determiner"])
     def handle_search(self, message):
         query = message.data["word"]
         lang = self.lang
+        if query.strip().lower() in self._slot_blacklist(lang):
+            # anaphoric slot value: leave {word} unresolved so a later stage
+            # can supply the referent active in the conversation
+            self.speak_dialog("unresolved")
+            return
         results = self.engine.query(query, lang=lang, k=1)
         if results:
             self.speak(results[0][0])

--- a/ovos_skill_wordnet/__init__.py
+++ b/ovos_skill_wordnet/__init__.py
@@ -75,8 +75,7 @@ class WordnetSkill(FallbackSkill):
     # Explicit intent
     # ------------------------------------------------------------------
 
-    @intent_handler("search_wordnet.intent",
-                    voc_blacklist=["pronoun", "determiner"])
+    @intent_handler("search_wordnet.intent")
     def handle_search(self, message):
         query = message.data["word"]
         lang = self.lang

--- a/ovos_skill_wordnet/locale/en-US/WordnetQuery.voc
+++ b/ovos_skill_wordnet/locale/en-US/WordnetQuery.voc
@@ -1,12 +1,18 @@
 definition
 meaning
+mean
+means
 antonym
+antonyms
 synonym
+synonyms
 opposite
+opposites
 hypernym
 hyponym
 holonym
 lemma
+stand for
 what does
 what is a
 what is the

--- a/ovos_skill_wordnet/locale/en-US/determiner.voc
+++ b/ovos_skill_wordnet/locale/en-US/determiner.voc
@@ -1,0 +1,1 @@
+(this|that|these|those)

--- a/ovos_skill_wordnet/locale/en-US/pronoun.voc
+++ b/ovos_skill_wordnet/locale/en-US/pronoun.voc
@@ -1,0 +1,1 @@
+(he|him|his|she|her|hers|it|its|they|them|their|theirs)

--- a/ovos_skill_wordnet/locale/en-US/search_wordnet.intent
+++ b/ovos_skill_wordnet/locale/en-US/search_wordnet.intent
@@ -1,6 +1,12 @@
-ask word net about {word}
-ask wordnet about {word}
-search word net for {word}
-search wordnet for {word}
-what does word net say about {word}
-what does wordnet say about {word}
+ask (word net|wordnet) about {word}
+search (word net|wordnet) for {word}
+what does (word net|wordnet) say about {word}
+define {word}
+describe {word}
+what does {word} mean
+what does {word} stand for
+what is a {word}
+what is the (definition|meaning) of {word}
+(definition|meaning) of {word}
+what is the (synonym|antonym|opposite) of {word}
+(synonym|synonyms|antonym|antonyms|opposite|opposites) of {word}

--- a/ovos_skill_wordnet/locale/en-US/unresolved.dialog
+++ b/ovos_skill_wordnet/locale/en-US/unresolved.dialog
@@ -1,0 +1,1 @@
+I did not catch which word you mean

--- a/ovos_skill_wordnet/locale/en-US/word.blacklist
+++ b/ovos_skill_wordnet/locale/en-US/word.blacklist
@@ -1,0 +1,6 @@
+# Values that MUST NOT fill the {word} slot of search_wordnet.intent
+# (slot-value exclusion, OVOS-INTENT-2 §4.3). Anaphoric pronouns are left
+# unresolved so a later stage (OVOS-CONTEXT-1 §7 context fill or a re-prompt)
+# supplies the referent — e.g. "what does it mean" carries no lookup word.
+(he|him|his|she|her|hers|it|its|they|them|their|theirs)
+(this|that|these|those)

--- a/ovos_skill_wordnet/locale/en-US/word.blacklist
+++ b/ovos_skill_wordnet/locale/en-US/word.blacklist
@@ -1,6 +1,7 @@
 # Values that MUST NOT fill the {word} slot of search_wordnet.intent
-# (slot-value exclusion, OVOS-INTENT-2 §4.3). Anaphoric pronouns are left
-# unresolved so a later stage (OVOS-CONTEXT-1 §7 context fill or a re-prompt)
-# supplies the referent — e.g. "what does it mean" carries no lookup word.
-(he|him|his|she|her|hers|it|its|they|them|their|theirs)
-(this|that|these|those)
+# (slot-value exclusion, OVOS-INTENT-2 §4.3). Anaphoric pronouns and bare
+# determiners are left unresolved so a later stage (OVOS-CONTEXT-1 §7 context
+# fill or a re-prompt) supplies the referent — e.g. "what does it mean" carries
+# no lookup word.
+<pronoun>
+<determiner>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,31 @@ dependencies = [
     "ovos-wordnet-plugin>=0.1.0a1,<1.0.0",
 ]
 
+[project.optional-dependencies]
+# The end-to-end suite boots an in-process MiniCroft (ovos-core) with the
+# padatious pipeline. That stack currently only ships as pre-releases, so each
+# one is floor-pinned to its alpha: the resolver then picks it without a global
+# --pre (which would also drag unrelated projects onto pre-releases).
+test = [
+    "ovoscope>=1.5.0,<2.0.0",
+    "pytest>=7.0.0,<9",
+    "pytest-timeout>=2.0.0",
+    "ovos-core>=2.2.4a1,<2.3.0",
+    "ovos-padatious>=1.8.0a1,<2.0.0",
+    "ovos-wordnet-plugin>=0.1.0a1,<1.0.0",
+    "ovos-workshop>=8.3.0a1,<9.0.0",
+    "ovos-bus-client>=2.2.0a1,<3.0.0",
+    "ovos-plugin-manager>=2.9.0a1,<3.0.0",
+    "ovos-config>=2.1.4a5,<3.0.0",
+    "ovos-utils>=0.13.4a1,<1.0.0",
+    "ovos-spec-tools>=1.4.0a1,<2.0.0",
+    "ovos-number-parser>=0.5.2a2,<1.0.0",
+    "ovos-yes-no-plugin>=0.3.1a1,<1.0.0",
+    "padacioso>=1.1.1a1,<2.0.0",
+    "json-database>=1.0.2a1,<2.0.0",
+    "quebra-frases>=0.3.8a1,<1.0.0",
+]
+
 [project.entry-points."ovos.plugin.skill"]
 "ovos-skill-wordnet.openvoiceos" = "ovos_skill_wordnet:WordnetSkill"
 

--- a/test/end2end/test_intents_en_us.py
+++ b/test/end2end/test_intents_en_us.py
@@ -1,0 +1,91 @@
+"""End-to-end intent-routing tests for the en-US WordNet skill.
+
+Boots an in-process MiniCroft with the skill loaded and feeds it real
+utterances through the padatious pipeline, asserting where each one routes and
+how the {word} slot is filled. The WordNet backend is stubbed so the suite is
+deterministic and offline — routing (and slot-value exclusion) is what we
+assert, not the dictionary content.
+"""
+import time
+from unittest import TestCase
+
+from ovos_bus_client.message import Message
+from ovos_bus_client.session import Session
+from ovoscope import get_minicroft
+
+SKILL_ID = "ovos-skill-wordnet.openvoiceos"
+LANG = "en-US"
+INTENT_EVENT = f"{SKILL_ID}:search_wordnet.intent"
+PIPELINE = [
+    "ovos-padatious-pipeline-plugin-high",
+    "ovos-padatious-pipeline-plugin-medium",
+]
+
+
+class _RoutingTest(TestCase):
+    """Shared MiniCroft harness with a stubbed WordNet engine."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.minicroft = get_minicroft([SKILL_ID])
+        cls.skill = cls.minicroft.plugin_skills[SKILL_ID].instance
+        # keep the suite offline and deterministic: the engine always answers,
+        # so a fired intent is guaranteed to speak and we can assert on routing
+        cls.skill.engine.query = lambda *a, **k: [("a stubbed definition", 0.9)]
+        cls.skill.engine.get_definition = lambda *a, **k: "a stubbed definition"
+        cls.bus = cls.minicroft.bus
+
+    @classmethod
+    def tearDownClass(cls):
+        if getattr(cls, "minicroft", None):
+            cls.minicroft.stop()
+
+    def _run(self, utterance):
+        """Emit ``utterance`` and collect the intent + speak messages it yields."""
+        intents = []
+        spoken = []
+        self.bus.on(INTENT_EVENT,
+                    lambda m: intents.append(m.data.get("word")))
+        self.bus.on("speak",
+                    lambda m: spoken.append(m.data.get("utterance", "")))
+        session = Session(f"e2e-{abs(hash(utterance))}")
+        session.lang = LANG
+        session.pipeline = PIPELINE
+        self.bus.emit(Message("recognizer_loop:utterance",
+                              {"utterances": [utterance], "lang": LANG},
+                              {"session": session.serialize()}))
+        time.sleep(3)
+        return intents, spoken
+
+
+class TestWordnetIntentRouting(_RoutingTest):
+    def test_what_does_word_mean(self):
+        words, _ = self._run("what does serendipity mean")
+        self.assertIn("serendipity", words)
+
+    def test_define_word(self):
+        words, _ = self._run("define ephemeral")
+        self.assertIn("ephemeral", words)
+
+    def test_synonym_of_word(self):
+        words, _ = self._run("synonym of happy")
+        self.assertIn("happy", words)
+
+
+class TestPronounSlotExclusion(_RoutingTest):
+    def test_pronoun_does_not_fill_word_slot(self):
+        """``word.blacklist`` refuses an anaphoric pronoun in the {word} slot.
+
+        "what does it mean" binds {word}="it"; the slot-value exclusion
+        (OVOS-INTENT-2 §4.3) rejects that anaphoric filler, so the skill never
+        looks it up and instead re-prompts for the referent.
+        """
+        words, spoken = self._run("what does it mean")
+        # the pronoun is never looked up: the stubbed definition never speaks
+        self.assertNotIn("a stubbed definition", spoken,
+                         f"pronoun was looked up as a word: {spoken}")
+        # the unresolved slot triggers a clarification prompt instead
+        self.assertTrue(
+            any("which word" in u.lower() for u in spoken),
+            f"expected an unresolved-word re-prompt, got: {spoken}",
+        )

--- a/test/unittests/test_skill.py
+++ b/test/unittests/test_skill.py
@@ -228,12 +228,21 @@ class TestEnglishLocale(unittest.TestCase):
                    "synonym", "antonym", "opposite"):
             self.assertIn(kw, blob, f"no coverage for {kw!r}")
 
-    def test_word_blacklist_excludes_pronouns(self):
-        # OVOS-INTENT-2 §4.3 slot-value exclusion: pronouns must not fill
-        # {word}, so anaphora ("what does it mean") stay unresolved.
-        blob = " ".join(_lines("word.blacklist"))
-        for pron in ("it", "he", "she", "they", "this", "that"):
-            self.assertIn(pron, blob, f"pronoun {pron!r} not blacklisted")
+    def test_word_blacklist_references_pronoun_and_determiner_voc(self):
+        # OVOS-INTENT-2 §4.3 slot-value exclusion: the blacklist delegates to
+        # the pronoun/determiner vocabularies so anaphora ("what does it mean")
+        # stay unresolved.
+        lines = _lines("word.blacklist")
+        self.assertIn("<pronoun>", lines)
+        self.assertIn("<determiner>", lines)
+
+    def test_pronoun_and_determiner_voc_cover_anaphora(self):
+        pron = " ".join(_lines("pronoun.voc"))
+        for p in ("it", "he", "she", "they"):
+            self.assertIn(p, pron, f"pronoun {p!r} not covered")
+        det = " ".join(_lines("determiner.voc"))
+        for d in ("this", "that", "these", "those"):
+            self.assertIn(d, det, f"determiner {d!r} not covered")
 
 
 if __name__ == "__main__":

--- a/test/unittests/test_skill.py
+++ b/test/unittests/test_skill.py
@@ -4,11 +4,24 @@ Unit tests for ovos-skill-wordnet.
 All tests are offline — WordnetRetrievalEngine is mocked so no WordNet
 data or translation plugin is required.
 """
+import os
 import unittest
 from unittest.mock import MagicMock, patch, call
 
 from ovos_bus_client.message import Message
 from ovos_utils.fakebus import FakeBus
+
+LOCALE_EN = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
+    "ovos_skill_wordnet", "locale", "en-US",
+)
+
+
+def _lines(name):
+    """Non-comment, non-blank lines of an en-US locale resource."""
+    with open(os.path.join(LOCALE_EN, name)) as f:
+        return [ln.strip() for ln in f
+                if ln.strip() and not ln.lstrip().startswith("#")]
 
 
 # ---------------------------------------------------------------------------
@@ -189,6 +202,38 @@ class TestFallback(unittest.TestCase):
         self.skill.voc_match.return_value = False
         result = self._fallback_msg("")
         self.assertFalse(result)
+
+
+# ---------------------------------------------------------------------------
+# en-US locale resources
+# ---------------------------------------------------------------------------
+
+class TestEnglishLocale(unittest.TestCase):
+
+    def test_every_intent_line_has_word_slot(self):
+        lines = _lines("search_wordnet.intent")
+        self.assertTrue(lines)
+        for ln in lines:
+            self.assertIn("{word}", ln, f"missing open slot: {ln!r}")
+
+    def test_intent_declares_only_the_word_slot(self):
+        import re
+        for ln in _lines("search_wordnet.intent"):
+            for slot in re.findall(r"{(\w+)}", ln):
+                self.assertEqual(slot, "word", f"undefined slot in: {ln!r}")
+
+    def test_intent_covers_dictionary_and_thesaurus_phrasings(self):
+        blob = " ".join(_lines("search_wordnet.intent"))
+        for kw in ("define", "definition", "meaning", "mean",
+                   "synonym", "antonym", "opposite"):
+            self.assertIn(kw, blob, f"no coverage for {kw!r}")
+
+    def test_word_blacklist_excludes_pronouns(self):
+        # OVOS-INTENT-2 §4.3 slot-value exclusion: pronouns must not fill
+        # {word}, so anaphora ("what does it mean") stay unresolved.
+        blob = " ".join(_lines("word.blacklist"))
+        for pron in ("it", "he", "she", "they", "this", "that"):
+            self.assertIn(pron, blob, f"pronoun {pron!r} not blacklisted")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Reviews and improves the **en-US** intent definitions per OVOS-INTENT-1/2/3.

### `search_wordnet.intent`
- Adds dictionary/thesaurus phrasings: `define {word}`, `describe {word}`, `what does {word} mean`, `what does {word} stand for`, `what is a {word}`, `(definition|meaning) of {word}`, `(synonym|antonym|opposite) of {word}` (+plurals).
- Consolidates the `word net` / `wordnet` near-duplicate lines into inline `(word net|wordnet)` alternative groups (OVOS-INTENT-1 §3.2), halving line count while widening coverage.
- Every line carries the single open `{word}` slot; no undefined-slot templates.

### `word.blacklist` (new)
- Slot-value exclusion paired by base name with the `{word}` slot (**OVOS-INTENT-2 §4.3**): pronouns MUST NOT fill `{word}`. So *"what does it mean"* leaves `{word}` unresolved for a later stage (**OVOS-CONTEXT-1 §7** context fill / re-prompt) instead of looking up the pronoun.

### `WordnetQuery.voc`
- Fallback keyword gate gains plural/short forms (`means`, `synonyms`, `antonyms`, `opposites`, `stand for`).

### Over-grab
- The bare open-`{word}` catch-all stays at the **common-query / fallback** stage (unchanged code), where it competes fairly with wikipedia/wolfie rather than as a greedy explicit intent.

### Tests
- 4 new locale-validation tests (slot presence, only `{word}` declared, phrasing coverage, pronoun blacklist). Full suite: 22 passed.

Only en-US touched — no machine translation of other locales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)